### PR TITLE
invalid metrics output - expected value after metric, got "MNAME"

### DIFF
--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -269,11 +269,13 @@ LUA
                 );
 
                 // Add the sum
+                $sumIndex = json_encode(array('b' => 'sum', 'labelValues' => $labelValues));
+                $sumValue = isset($raw[$sumIndex]) ? $raw[$sumIndex] : 0;
                 $histogram['samples'][] = array(
                     'name' => $histogram['name'] . '_sum',
                     'labelNames' => array(),
                     'labelValues' => $labelValues,
-                    'value' => $raw[json_encode(array('b' => 'sum', 'labelValues' => $labelValues))]
+                    'value' => $sumValue
                 );
             }
             $histograms[] = $histogram;


### PR DESCRIPTION
## Problem
Using **redis** storage, in case of wrong / unlucky label configuration of a histogram entry, the redered metrics output can be invalid. Prometheus failed to scrape the output with this error: `expected value after metric, got "MNAME"`

This PR tries to fix this problem, by defaulting to **0** value in such cases.

## Detailed description
A rendered output looked like this:
```
# previous lines removed ...
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="1"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="5"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="10"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="15"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="30"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="45"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="60"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="120"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="180"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="300"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="600"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="900"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="1200"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="1500"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="1800"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_bucket{status="30",payment_type_id="Array",le="+Inf"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_count{status="30",payment_type_id="Array"} 0
webshop_transaction_lifecycle_duration_histogram_seconds_sum{status="30",payment_type_id="Array"}
```
Note, that the last line does **NOT** contain a value at the end, and this causes the error at parsing on the prometheus side.

As you can see, I misconfigured the `payment_type_id` label value, and it resulted in an undefined array index. The `value` item got a `null` value in the `$histogram` array then it was rendered as an empty string

IMHO misconfigurations like this **must not result in an invalid output**.